### PR TITLE
Fix wrong UnitDto on angular an implement Unit translator

### DIFF
--- a/Hogajama/hogajama-angular-frontend/src/main/ionic/src/app/modules/shared/unit-dialog/unit-dialog.component.html
+++ b/Hogajama/hogajama-angular-frontend/src/main/ionic/src/app/modules/shared/unit-dialog/unit-dialog.component.html
@@ -15,7 +15,7 @@
     </mat-form-field>
     <mat-form-field>
       <mat-label>Is Default?</mat-label>
-      <mat-select [(value)]="unit.isDefault">
+      <mat-select [(value)]="unit.defaultUnit">
         <mat-option [value]="true">True</mat-option>
         <mat-option [value]="false">False</mat-option>
       </mat-select>

--- a/Hogajama/hogajama-angular-frontend/src/main/ionic/src/app/shared/models/Unit.ts
+++ b/Hogajama/hogajama-angular-frontend/src/main/ionic/src/app/shared/models/Unit.ts
@@ -1,7 +1,7 @@
 export interface Unit {
     id?: number;
     description?: string;
-    isDefault?: boolean;
+    defaultUnit?: boolean;
     name?: string;
     ownerId?: number;
 }

--- a/Hogajama/hogajama-rs/src/main/java/com/gepardec/hogarama/rest/unitmanagement/translator/UnitDtoTranslator.java
+++ b/Hogajama/hogajama-rs/src/main/java/com/gepardec/hogarama/rest/unitmanagement/translator/UnitDtoTranslator.java
@@ -1,16 +1,15 @@
 package com.gepardec.hogarama.rest.unitmanagement.translator;
 
-import com.gepardec.hogarama.domain.unitmanagement.dao.OwnerDAO;
+import com.gepardec.hogarama.domain.unitmanagement.context.UserContext;
 import com.gepardec.hogarama.domain.unitmanagement.entity.Unit;
 import com.gepardec.hogarama.rest.unitmanagement.dto.UnitDto;
-import org.apache.commons.lang3.NotImplementedException;
 
 import javax.inject.Inject;
 
 public class UnitDtoTranslator implements Translator<UnitDto, Unit> {
 
     @Inject
-    private OwnerDAO ownerDAO;
+    private UserContext userContext;
 
     @Override
     public UnitDto toDto(Unit unit) {
@@ -23,6 +22,12 @@ public class UnitDtoTranslator implements Translator<UnitDto, Unit> {
 
     @Override
     public Unit fromDto(UnitDto dto) {
-        throw new NotImplementedException("Not necessary yet.");
-    }
+        Unit unit = new Unit();
+        unit.setDescription(dto.getDescription());
+        unit.setName(dto.getName());
+        unit.setId(dto.getId());
+        unit.setOwner(userContext.getOwner()); // We always use the current Owner? Should OwnerId be in Dto?
+        unit.setDefaultUnit(dto.isDefaultUnit());
+        return unit;
+     }
 }

--- a/Hogajama/hogajama-rs/src/test/java/com/gepardec/hogarama/rest/unitmanagement/translator/UnitDtoTranslatorTest.java
+++ b/Hogajama/hogajama-rs/src/test/java/com/gepardec/hogarama/rest/unitmanagement/translator/UnitDtoTranslatorTest.java
@@ -1,0 +1,54 @@
+package com.gepardec.hogarama.rest.unitmanagement.translator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.gepardec.hogarama.domain.unitmanagement.context.UserContext;
+import com.gepardec.hogarama.domain.unitmanagement.entity.Owner;
+import com.gepardec.hogarama.domain.unitmanagement.entity.Unit;
+import com.gepardec.hogarama.rest.unitmanagement.dto.UnitDto;
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class UnitDtoTranslatorTest {
+
+    private static final String EXAMPLE_UNIT = "ExampleUnit";
+	private static final long OWNER_ID = 5L;
+    private static final long UNIT_ID = 2L;
+
+    @Mock
+    private UserContext userContext;
+
+    @InjectMocks
+    private UnitDtoTranslator translator;
+
+    @Test
+    public void fromDto() {
+    	UnitDto dto = new UnitDto();
+    	dto.setDefaultUnit(false);
+    	dto.setDescription("A Example Unit");
+    	dto.setId(UNIT_ID);
+    	dto.setName(EXAMPLE_UNIT);
+    	
+    	Mockito.when(userContext.getOwner()).thenReturn(currentOwner());
+ 
+        Unit result = translator.fromDto(dto);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(UNIT_ID);
+        assertThat(result.getOwner().getId()).isEqualTo(OWNER_ID);
+        assertThat(result.getName()).isEqualTo(EXAMPLE_UNIT);
+     }
+
+    private Owner currentOwner() {
+		Owner owner = new Owner();
+		owner.setId(OWNER_ID);
+		return owner;
+	}
+}

--- a/OpenShift3/Templates/local_openshift/hogarama-jboss.yaml
+++ b/OpenShift3/Templates/local_openshift/hogarama-jboss.yaml
@@ -119,10 +119,6 @@ objects:
             value: ${TINYURL}
           - name: KEYCLOAK_AUTH_SERVER_URL
             value: ${KEYCLOAK_AUTH_SERVER_URL}
-          - name: POSTGRESQL_DATABASE
-            value: units
-          - name: POSTGRESQL_USER
-            value: hogarama
           - name: POSTGRESQL_PASSWORD
             value: changepassword
           - name: CURRENT_NAMESPACE


### PR DESCRIPTION
Should fix #338.
When we use current owner for creating Units, should we have ownerId in UnitDto?