### PR TITLE
fix prometheus persistence configuration

### DIFF
--- a/OCP-Infrastructure/helm/prometheus/templates/crd.yaml
+++ b/OCP-Infrastructure/helm/prometheus/templates/crd.yaml
@@ -14,11 +14,13 @@ spec:
   additionalScrapeConfigs:
     name: prometheus-scrape-config
     key: scrape-config.yaml
-  volumes:
-    - name: prometheus-persistence
-      persistentVolumeClaim:
-        claimName: prometheus-pvc
-        readOnly: false
+  storage:
+    volumeClaimTemplate:
+      spec:
+        storageClassName: rook-ceph-block
+        resources:
+          requests:
+            storage: 15Gi
   resources: 
     requests:
       memory: 128Mi


### PR DESCRIPTION
should fix configuration of prometheus persistence configuration according to its api-documentation. 

https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/user-guides/storage.md


@mahaupt could you change the cofiguration on the cluster? I don't seem to have the needed permissions to do so myself. 
