### PR TITLE
Add --allow-root to npm install

### DIFF
--- a/Hogajama/hogajama-angular-frontend/pom.xml
+++ b/Hogajama/hogajama-angular-frontend/pom.xml
@@ -70,6 +70,9 @@
                         <goals>
                             <goal>npm</goal>
                         </goals>
+                        <configuration>
+                            <arguments>install --unsafe-perm=true --allow-root</arguments>
+                        </configuration>
                     </execution>
                     <execution>
                         <id>npm rebuild node-sass</id>


### PR DESCRIPTION
command failed: sh -c node install.js:

- permission denied for mkdir '/.cache'