### PR TITLE
- This version fixes node download link not working when built on MAC…

### DIFF
--- a/Hogajama/hogajama-angular-frontend/pom.xml
+++ b/Hogajama/hogajama-angular-frontend/pom.xml
@@ -53,7 +53,6 @@
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
-                <version>1.11.3</version>
                 <configuration>
                     <nodeVersion>${version.node}</nodeVersion>
                     <npmVersion>${version.npm}</npmVersion>

--- a/Hogajama/hogajama-angular-frontend/pom.xml
+++ b/Hogajama/hogajama-angular-frontend/pom.xml
@@ -53,6 +53,7 @@
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
+                <version>1.11.3</version>
                 <configuration>
                     <nodeVersion>${version.node}</nodeVersion>
                     <npmVersion>${version.npm}</npmVersion>

--- a/Hogajama/pom.xml
+++ b/Hogajama/pom.xml
@@ -304,7 +304,7 @@
 				<plugin>
 					<groupId>com.github.eirslett</groupId>
 					<artifactId>frontend-maven-plugin</artifactId>
-					<version>1.7.5</version>
+					<version>1.11.3</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>


### PR DESCRIPTION
- Fixes a broken download link when built on Apple MAC Book with silicon architecture.

- Building works on apple silicon but not sure if this has a greater impact or not.