### PR TITLE
Feature/gpx 534

### DIFF
--- a/OCP-Infrastructure/helm/hogajama/templates/hogajama-alerts.yaml
+++ b/OCP-Infrastructure/helm/hogajama/templates/hogajama-alerts.yaml
@@ -17,3 +17,5 @@ spec:
               Stunde Messdauer)! Vermutlich ein Fehler in der Kommunikation mit
               den Habarama Clients.
           expr: 'sum(changes(hogarama_sensor_value[1h]))==0'
+          labels:
+            severity: critical

--- a/OCP-Infrastructure/helm/hogajama/templates/hogajama-alerts.yaml
+++ b/OCP-Infrastructure/helm/hogajama/templates/hogajama-alerts.yaml
@@ -1,0 +1,31 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  creationTimestamp: '2022-12-12T12:00:39Z'
+  generation: 1
+  managedFields:
+    - apiVersion: monitoring.coreos.com/v1
+      fieldsType: FieldsV1
+      fieldsV1:
+        'f:spec':
+          .: {}
+          'f:groups': {}
+      manager: Mozilla
+      operation: Update
+      time: '2022-12-12T12:00:39Z'
+  name: hogajama-alerts
+  namespace: hogarama
+  resourceVersion: '241431567'
+  uid: 8332bfaa-6e7c-468c-8777-8da74c15c1ff
+spec:
+  groups:
+    - name: alerts-sensor
+      rules:
+        - alert: hogarama-no-sensor
+          annotations:
+            description: Der Sensor von Hogarama hat für 10min keine Werte zurückgeliefert!
+            summary: Der Sensor hat einen Fehler
+          expr: 'changes(hogarama_sensor_value[10m])==0'
+          for: 2m
+          labels:
+            severity: critical

--- a/OCP-Infrastructure/helm/hogajama/templates/hogajama-alerts.yaml
+++ b/OCP-Infrastructure/helm/hogajama/templates/hogajama-alerts.yaml
@@ -1,22 +1,8 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  creationTimestamp: '2022-12-12T12:00:39Z'
-  generation: 1
-  managedFields:
-    - apiVersion: monitoring.coreos.com/v1
-      fieldsType: FieldsV1
-      fieldsV1:
-        'f:spec':
-          .: {}
-          'f:groups': {}
-      manager: Mozilla
-      operation: Update
-      time: '2022-12-12T12:00:39Z'
   name: hogajama-alerts
   namespace: hogarama
-  resourceVersion: '241431567'
-  uid: 8332bfaa-6e7c-468c-8777-8da74c15c1ff
 spec:
   groups:
     - name: alerts-sensor

--- a/OCP-Infrastructure/helm/hogajama/templates/hogajama-alerts.yaml
+++ b/OCP-Infrastructure/helm/hogajama/templates/hogajama-alerts.yaml
@@ -9,9 +9,11 @@ spec:
       rules:
         - alert: hogarama-no-sensor
           annotations:
-            description: Der Sensor von Hogarama hat für 10min keine Werte zurückgeliefert!
-            summary: Der Sensor hat einen Fehler
-          expr: 'changes(hogarama_sensor_value[10m])==0'
-          for: 2m
-          labels:
-            severity: critical
+            description: >-
+              Alle Sensoren von Hogarama haben für 1h keine Werte
+              zurückgeliefert!
+            summary: >-
+              Von den Sensoren wurden keine neuen Sensordaten empfangen (Eine
+              Stunde Messdauer)! Vermutlich ein Fehler in der Kommunikation mit
+              den Habarama Clients.
+          expr: 'sum(changes(hogarama_sensor_value[1h]))==0'


### PR DESCRIPTION
PrometheusRule, die im Zuge des Tickets GPX-534 von Gepardec Run erstellt wurde. Sie führt dazu, dass ein Alert in den Slack-Channel "hogarama-alerts" gepostet wird, wenn es für 10min keine Änderungen in den Sensorwerten gab.